### PR TITLE
FEATURE - Aplicando padrão DTO (validações e retorno de consulta para o usuário)

### DIFF
--- a/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/controller/AbrigoController.java
+++ b/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/controller/AbrigoController.java
@@ -1,5 +1,6 @@
 package br.com.alura.adopet.api.controller;
 
+import br.com.alura.adopet.api.dto.DadosDetalhesPet;
 import br.com.alura.adopet.api.model.Abrigo;
 import br.com.alura.adopet.api.model.Pet;
 import br.com.alura.adopet.api.repository.AbrigoRepository;
@@ -10,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -40,17 +42,33 @@ public class AbrigoController {
     }
 
     @GetMapping("/{idOuNome}/pets")
-    public ResponseEntity<List<Pet>> listarPets(@PathVariable String idOuNome) {
+    public ResponseEntity<List<DadosDetalhesPet>> listarPets(@PathVariable String idOuNome) {
         try {
             Long id = Long.parseLong(idOuNome);
             List<Pet> pets = repository.getReferenceById(id).getPets();
-            return ResponseEntity.ok(pets);
+            List<DadosDetalhesPet> dadosPets = new ArrayList<>();
+
+            for (Pet pet : pets) {
+                if (!pet.getAdotado()) {
+                    dadosPets.add(new DadosDetalhesPet(pet));
+                }
+            }
+            return ResponseEntity.ok(dadosPets);
+
         } catch (EntityNotFoundException enfe) {
             return ResponseEntity.notFound().build();
         } catch (NumberFormatException e) {
             try {
                 List<Pet> pets = repository.findByNome(idOuNome).getPets();
-                return ResponseEntity.ok(pets);
+                List<DadosDetalhesPet> dadosPets = new ArrayList<>();
+
+                for (Pet pet : pets) {
+                    if (!pet.getAdotado()) {
+                        dadosPets.add(new DadosDetalhesPet(pet));
+                    }
+                }
+                return ResponseEntity.ok(dadosPets);
+
             } catch (EntityNotFoundException enfe) {
                 return ResponseEntity.notFound().build();
             }

--- a/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/controller/PetController.java
+++ b/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/controller/PetController.java
@@ -1,5 +1,6 @@
 package br.com.alura.adopet.api.controller;
 
+import br.com.alura.adopet.api.dto.DadosDetalhesPet;
 import br.com.alura.adopet.api.model.Pet;
 import br.com.alura.adopet.api.repository.PetRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,12 +20,13 @@ public class PetController {
     private PetRepository repository;
 
     @GetMapping
-    public ResponseEntity<List<Pet>> listarTodosDisponiveis() {
+    public ResponseEntity<List<DadosDetalhesPet>> listarTodosDisponiveis() {
         List<Pet> pets = repository.findAll();
-        List<Pet> disponiveis = new ArrayList<>();
+        List<DadosDetalhesPet> disponiveis = new ArrayList<>();
+
         for (Pet pet : pets) {
-            if (pet.getAdotado() == false) {
-                disponiveis.add(pet);
+            if (!pet.getAdotado()) {
+                disponiveis.add(new DadosDetalhesPet(pet));
             }
         }
         return ResponseEntity.ok(disponiveis);

--- a/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/dto/AprovacaoAdocaoDto.java
+++ b/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/dto/AprovacaoAdocaoDto.java
@@ -1,6 +1,9 @@
 package br.com.alura.adopet.api.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public record AprovacaoAdocaoDto(
+        @NotNull
         Long idAdocao
 ) {
 }

--- a/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/dto/DadosDetalhesPet.java
+++ b/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/dto/DadosDetalhesPet.java
@@ -1,0 +1,16 @@
+package br.com.alura.adopet.api.dto;
+
+import br.com.alura.adopet.api.model.Pet;
+import br.com.alura.adopet.api.model.TipoPet;
+
+public record DadosDetalhesPet(
+        Long id,
+        TipoPet tipo,
+        String nome,
+        String raca,
+        Integer idade) {
+
+    public DadosDetalhesPet(Pet pet) {
+        this(pet.getId(), pet.getTipo(), pet.getNome(), pet.getRaca(), pet.getIdade());
+    }
+}

--- a/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/dto/ReprovacaoAdocaoDto.java
+++ b/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/dto/ReprovacaoAdocaoDto.java
@@ -1,7 +1,14 @@
 package br.com.alura.adopet.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record ReprovacaoAdocaoDto(
+
+        @NotNull
         Long idAdocao,
+
+        @NotBlank
         String motivo
 ) {
 }

--- a/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/dto/SolicitacaoAdocaoDto.java
+++ b/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/dto/SolicitacaoAdocaoDto.java
@@ -1,8 +1,16 @@
 package br.com.alura.adopet.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record SolicitacaoAdocaoDto(
+        @NotNull
         Long idPet,
+
+        @NotNull
         Long idTutor,
+
+        @NotBlank
         String motivo
 ) {
 }

--- a/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/model/Adocao.java
+++ b/boas-praticas-java-projeto_inicial/src/main/java/br/com/alura/adopet/api/model/Adocao.java
@@ -21,19 +21,16 @@ public class Adocao {
     @Column(name = "data")
     private LocalDateTime data;
 
-    @NotNull
     @ManyToOne
     @JsonBackReference("tutor_adocoes")
     @JoinColumn(name = "tutor_id")
     private Tutor tutor;
 
-    @NotNull
     @OneToOne
     @JoinColumn(name = "pet_id")
     @JsonManagedReference("adocao_pets")
     private Pet pet;
 
-    @NotBlank
     @Column(name = "motivo")
     private String motivo;
 


### PR DESCRIPTION
Com essas modificações, as validações que antes eram feitas na classe JPA foram transferidas para o record, que agora é recebido como parâmetro nas rotas configuradas e validado com a anotação @Valid.

Além disso, aproveitando a mudança, o retorno também foi alterado. Antes, a classe JPA era retornada diretamente; agora, utilizamos um record específico para os detalhes do Pet.

Esses conceitos foram apresentados no minicurso da Alura sobre DTO (Data Transfer Object).